### PR TITLE
Added link to williamcaputo.com

### DIFF
--- a/speakers.html
+++ b/speakers.html
@@ -159,7 +159,7 @@
             <li><a href="http://grahamis.com/blog/">Josh Graham</a>
 
               <p>Speaker: 2009, 2010, 2011, and 2012</p></li>
-            <li><a href="">Bill Caputo</a>
+            <li><a href="http://www.williamcaputo.com/">Bill Caputo</a>
 
               <p>Speaker: 2011</p></li>
             <li><a href="http://www.theagiledeveloper.com/">Matt Deiters</a>


### PR DESCRIPTION
changed the link on the speakers page for "Bill Caputo" to point to www.williamcaputo.com
